### PR TITLE
Use double backslashes to correctly escape Windows paths in Puppet

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -59,16 +59,16 @@ class winlogbeat::install {
   }
 
   exec { "create service entry ${filename}":
-    command => "New-Service -Name winlogbeat -displayName Winlogbeat  -binaryPathName '\"C:\Program Files\Winlogbeat\winlogbeat.exe\" -c \"C:\Program Files\Winlogbeat\winlogbeat.yml\" -path.home \"C:\Program Files\Winlogbeat\" -path.data \"C:\ProgramData\winlogbeat\" -path.logs \"C:\ProgramData\winlogbeat\logs\"'",
+    command     => "New-Service -Name winlogbeat -displayName Winlogbeat  -binaryPathName '\"C:\\Program Files\\Winlogbeat\\winlogbeat.exe\" -c \"C:\\Program Files\\Winlogbeat\\winlogbeat.yml\" -path.home \"C:\\Program Files\\Winlogbeat\" -path.data \"C:\\ProgramData\\winlogbeat\" -path.logs \"C:\\ProgramData\\winlogbeat\\logs\"'",
     refreshonly => true,
     subscribe   => [ Exec["mark ${filename}"] ],
   }
-  
+
   # exec { "install ${filename}":
   #  cwd         => $install_folder,
   #  command     => './install-service-winlogbeat.ps1',
   #  refreshonly => true,
   #  subscribe   => [ Exec["create service entry ${filename}"], Exec["mark ${filename}"] ],
   #}
-  
+
 }


### PR DESCRIPTION
Changed escapes to be double backslashes rather than one
